### PR TITLE
Fixed issue where global inputs could get cached for parent switches.

### DIFF
--- a/gutter/client/models.py
+++ b/gutter/client/models.py
@@ -310,6 +310,7 @@ class Manager(threading.local):
 
     def __getstate__(self):
         inner_dict = vars(self).copy()
+        inner_dict.pop('inputs', False)
         inner_dict.pop('storage', False)
         return inner_dict
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -368,3 +368,17 @@ class TestIntegrationWithRedis(TestIntegration):
     @fixture
     def manager(self):
         return Manager(storage=RedisDict('gutter-tests', self.redis))
+
+    def test_parent_switch_pickle_input(self):
+        import pickle
+
+        # Passing in module `pickle` as unpicklable input.
+        evil = User(deterministicstring('evil'), pickle)
+        self.manager.input(evil)
+
+        self.manager.autocreate = True
+
+        try:
+            self.manager.active('new:switch')
+        except pickle.PicklingError, e:
+            self.fail('Encountered pickling error: "%s"' % e)


### PR DESCRIPTION
This is a workaround for a bug where an input could be unpicklable, and
auto-creating switches would fail when the manager has an unpicklable
input.

The underlying issue (which still exists) is that Manager.register handles
unsetting Switch.manager before persisting except it does not take into
account parent switches having managers attached still.
