### PR TITLE
Fix spelling of "consent".

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,23 +208,23 @@ You can create switches using a specific hierarchical naming scheme.  Switch nam
 
 In the above example, the ``child1`` switch is a child of the ``"movies"`` switch because it has ``movies:`` as a prefix to the switch name.  Both ``child1`` and ``child2`` are "children of the parent ``parent`` switch.  And ``grandchild`` is a child of the ``child1`` switch, but *not* the ``child2`` switch.
 
-Concent
+Consent
 ~~~~~~~
 
 By default, each switch makes its "am I active?" decision independent of other switches in the Manager (including its parent), and only consults its own conditions to check if it is enabled for the input.  However, this is not always the case.  Perhaps you have a cool new feature that is only available to a certain class of user.  And of *those* users, you want 10% to be be exposed to a different user interface to see how they behave vs the other 90%.
 
-``gutter`` allows you to set a ``concent`` flag on a switch that instructs it to check its parental switch first, before checking itself.  If it checks its parent and it is not enabled for the same input, the switch immediately returns ``False``.  If its parent *is* enabled for the input, then the switch will continue and check its own conditions, returning as it would normally.
+``gutter`` allows you to set a ``consent`` flag on a switch that instructs it to check its parental switch first, before checking itself.  If it checks its parent and it is not enabled for the same input, the switch immediately returns ``False``.  If its parent *is* enabled for the input, then the switch will continue and check its own conditions, returning as it would normally.
 
 For example:
 
 .. code:: python
 
     parent = Switch('cool_new_feature')
-    child = Switch('cool_new_feature:new_ui', concent=True)
+    child = Switch('cool_new_feature:new_ui', consent=True)
 
-For example, because ``child`` was constructed with ``concent=True``, even if ``child`` is enabled for an input, it will only return ``True`` if ``parent`` is **also** enabled for that same input.
+For example, because ``child`` was constructed with ``consent=True``, even if ``child`` is enabled for an input, it will only return ``True`` if ``parent`` is **also** enabled for that same input.
 
-**Note:** Even switches in a ``GLOBAL`` or ``DISABLED`` state (see "Switch" section above) still consent their parent before checking themselves.  That means that even if a particular switch is ``GLOBAL``, if it has ``concent`` set to ``True`` and its parent is **not** enabled for the input, the switch itself will return ``False``.
+**Note:** Even switches in a ``GLOBAL`` or ``DISABLED`` state (see "Switch" section above) still consent their parent before checking themselves.  That means that even if a particular switch is ``GLOBAL``, if it has ``consent`` set to ``True`` and its parent is **not** enabled for the input, the switch itself will return ``False``.
 
 Registering a Switch
 ~~~~~~~~~~~~~~~~~~~~
@@ -395,14 +395,14 @@ The ``switch_updated`` signal can be connected to in order to be notified when a
 
     >>> from gutter.client.models import Switch
     >>> switch = Switch('test')
-    >>> switch.concent
+    >>> switch.consent
     True
-    >>> switch.concent = False
+    >>> switch.consent = False
     >>> switch.name = 'new name'
     >>> switch.changes
-    {'concent': {'current': False, 'previous': True}, 'name': {'current': 'new name', 'previous': 'test'}}
+    {'consent': {'current': False, 'previous': True}, 'name': {'current': 'new name', 'previous': 'test'}}
 
-As you can see, when we changed the Switch's ``concent`` setting and ``name``, ``switch.changes`` reflects that in a dictionary of changed properties.  You can also simply ask the switch if anything has changed with the ``changed`` property.  It returns ``True`` or ``False`` if the switch has any changes as all.
+As you can see, when we changed the Switch's ``consent`` setting and ``name``, ``switch.changes`` reflects that in a dictionary of changed properties.  You can also simply ask the switch if anything has changed with the ``changed`` property.  It returns ``True`` or ``False`` if the switch has any changes as all.
 
 You can use these values inside your signal callback to make decisions based on what changed.  I.e., email out a diff only if the changes include changed conditions.
 

--- a/gutter/client/models.py
+++ b/gutter/client/models.py
@@ -31,7 +31,7 @@ class Switch(object):
         GLOBAL = 3
 
     def __init__(self, name, state=states.DISABLED, compounded=False,
-                 parent=None, concent=True, manager=None, label=None,
+                 parent=None, consent=True, manager=None, label=None,
                  description=None):
         self._name = str(name)
         self.label = label
@@ -40,7 +40,7 @@ class Switch(object):
         self.conditions = list()
         self.compounded = compounded
         self.parent = parent
-        self.concent = concent
+        self.consent = consent
         self.children = []
         self.manager = manager
         self.reset()
@@ -53,7 +53,7 @@ class Switch(object):
         kwargs = dict(
             state=self.state,
             compounded=self.compounded,
-            concent=self.concent
+            consent=self.consent
         )
         parts = ["%s=%s" % (k, v) for k, v in kwargs.items()]
         return '<Switch("%s") conditions=%s, %s>' % (
@@ -67,7 +67,7 @@ class Switch(object):
                 self.name == other.name and
                 self.state is other.state and
                 self.compounded is other.compounded and
-                self.concent is other.concent
+                self.consent is other.consent
             )
 
     def __getstate__(self):
@@ -414,7 +414,7 @@ class Manager(threading.local):
         # If necessary, the switch first consents with its parent and returns
         # false if the switch is consenting and the parent is not enabled for
         # ``inputs``.
-        if switch.concent and switch.parent and not self.active(switch.parent, *inputs, **kwargs):
+        if switch.consent and switch.parent and not self.active(switch.parent, *inputs, **kwargs):
             return False
 
         return any(map(switch.enabled_for, inputs))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -129,7 +129,7 @@ class TestIntegration(Exam, unittest2.TestCase):
         self.add_switch('can drink', condition=self.age_21_plus)
         self.add_switch('can drink in europe', condition=self.age_21_plus, state=Switch.states.GLOBAL)
         self.add_switch('can drink:answer to life', condition=self.answer_to_life)
-        self.add_switch('can drink:wine', condition=self.in_sf, concent=True)
+        self.add_switch('can drink:wine', condition=self.in_sf, consent=True)
         self.add_switch('retired', condition=self.age_65_and_up)
         self.add_switch('can vote', condition=self.age_not_under_18)
         self.add_switch('teenager', condition=self.age_between_13_and_18)
@@ -208,7 +208,7 @@ class TestIntegration(Exam, unittest2.TestCase):
             ok_(context.active('10 percent') is False)
             ok_(context.active('Upper 50 percent') is True)
 
-    def test_switches_can_concent_top_parent_switch(self):
+    def test_switches_can_consent_top_parent_switch(self):
         with self.inputs(self.manager, self.jeff) as context:
             ok_(context.active('can drink') is True)
             ok_(context.active('can drink in europe') is True)
@@ -344,7 +344,7 @@ class TestIntegration(Exam, unittest2.TestCase):
             Switch.states.GLOBAL
         )
 
-    def test_concent_with_different_arguments(self):
+    def test_consent_with_different_arguments(self):
         # Test that a parent switch with a different argument type from the
         # child works.
         with self.inputs(self.manager, self.jeff, 42) as context:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -42,7 +42,7 @@ class TestSwitch(unittest2.TestCase):
     possible_properties = [
         ('state', (Switch.states.DISABLED, Switch.states.SELECTIVE)),
         ('compounded', (True, False)),
-        ('concent', (True, False))
+        ('consent', (True, False))
     ]
 
     def test_legacy_unpickle(self):
@@ -143,11 +143,11 @@ class TestSwitch(unittest2.TestCase):
     def test_can_be_constructed_with_parent(self):
         eq_(Switch('foo', parent='dog').parent, 'dog')
 
-    def test_concent_defaults_to_true(self):
-        eq_(Switch('foo').concent, True)
+    def test_consent_defaults_to_true(self):
+        eq_(Switch('foo').consent, True)
 
-    def test_can_be_constructed_with_concent(self):
-        eq_(Switch('foo', concent=False).concent, False)
+    def test_can_be_constructed_with_consent(self):
+        eq_(Switch('foo', consent=False).consent, False)
 
     def test_children_defaults_to_an_empty_list(self):
         eq_(Switch('foo').children, [])
@@ -232,11 +232,11 @@ class TestSwitchChanges(unittest2.TestCase):
             dict(state=self.changes_dict(1, 'new name'))
         )
 
-        self.switch.concent = False
+        self.switch.consent = False
         eq_(self.switch.changes,
             dict(
                 state=self.changes_dict(1, 'new name'),
-                concent=self.changes_dict(True, False)
+                consent=self.changes_dict(True, False)
             )
         )
 
@@ -350,7 +350,7 @@ class SwitchWithConditions(object):
         return mck
 
 
-class ConcentTest(Exam, SwitchWithConditions, unittest2.TestCase):
+class ConsentTest(Exam, SwitchWithConditions, unittest2.TestCase):
 
     @fixture
     def manager(self):
@@ -375,7 +375,7 @@ class ConcentTest(Exam, SwitchWithConditions, unittest2.TestCase):
         for cond in self.switch.conditions:
             cond.call.return_value = val
 
-    def test_with_concent_only_enabled_if_parent_is_too(self):
+    def test_with_consent_only_enabled_if_parent_is_too(self):
         self.manager.register(self.switch)
 
         parent = self.manager.switch(self.switch.parent)
@@ -385,8 +385,8 @@ class ConcentTest(Exam, SwitchWithConditions, unittest2.TestCase):
         parent.state = Switch.states.GLOBAL
         eq_(self.manager.active('parent:with conditions', 'input'), True)
 
-    def test_without_concent_ignores_parents_enabled_status(self):
-        self.switch.concent = False
+    def test_without_consent_ignores_parents_enabled_status(self):
+        self.switch.consent = False
 
         parent = self.manager.switch(self.switch.parent)
         eq_(parent.enabled_for('input'), False)


### PR DESCRIPTION
WARNING: this is a breaking change.
