### PR TITLE
Simplify parent and child logic

### DIFF
--- a/gutter-client.sublime-project
+++ b/gutter-client.sublime-project
@@ -1,25 +1,38 @@
 {
- "folders": [
-  {
-   "folder_exclude_patterns": [
-    "*.egg",
-    "build",
-    "dist",
-    "*.egg-info",
-    "doc/_*",
-    ".ropeproject"
-   ],
-   "file_exclude_patterns": [
-    "*.egg",
-    "*.sublime-workspace",
-    "*_pb2.py"
-   ],
-   "path": "."
-  }
- ],
- "settings": {
-  "tab_size": 4,
-  "translate_tabs_to_spaces": true,
-  "trim_trailing_white_space_on_save": true
-  }
+	"build_systems":
+	[
+		{
+			"file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
+			"name": "Anaconda Python Builder",
+			"selector": "source.python",
+			"shell_cmd": "python -u \"$file\""
+		}
+	],
+	"folders":
+	[
+		{
+			"file_exclude_patterns":
+			[
+				"*.egg",
+				"*.sublime-workspace",
+				"*_pb2.py"
+			],
+			"folder_exclude_patterns":
+			[
+				"*.egg",
+				"build",
+				"dist",
+				"*.egg-info",
+				"doc/_*",
+				".ropeproject"
+			],
+			"path": "."
+		}
+	],
+	"settings":
+	{
+		"tab_size": 4,
+		"translate_tabs_to_spaces": true,
+		"trim_trailing_white_space_on_save": true
+	}
 }

--- a/gutter/client/arguments/base.py
+++ b/gutter/client/arguments/base.py
@@ -40,6 +40,7 @@ class argument(object):
 
 
 class Container(object):
+
     """
     Base class for Arguments, which are responsible for understanding inputs
     and returning Argument Variables.  Argument variables are compared against

--- a/gutter/client/arguments/base.py
+++ b/gutter/client/arguments/base.py
@@ -1,3 +1,6 @@
+from types import NoneType
+
+
 class classproperty(object):
 
     def __init__(self, getter):
@@ -48,7 +51,7 @@ class Container(object):
     the specified input.
     """
 
-    COMPATIBLE_TYPE = None
+    COMPATIBLE_TYPE = NoneType
 
     def __init__(self, inpt):
         self.input = inpt
@@ -62,4 +65,4 @@ class Container(object):
 
     @property
     def applies(self):
-        return type(self.input) is self.COMPATIBLE_TYPE
+        return isinstance(self.input, self.COMPATIBLE_TYPE)

--- a/gutter/client/encoding.py
+++ b/gutter/client/encoding.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+# Standard Library
+import pickle as old_pickle
+
+# External Libraries
+import jsonpickle as pickle
+
+
+class JsonPickleEncoding(object):
+    @staticmethod
+    def encode(data):
+        return pickle.dumps(data)
+
+    @staticmethod
+    def decode(data):
+        try:
+            return pickle.loads(data)
+        except Exception:
+            return old_pickle.loads(data)

--- a/gutter/client/models.py
+++ b/gutter/client/models.py
@@ -25,7 +25,6 @@ def all_false_if_empty(iterable):
 
 
 class ConditionsDict(defaultdict):
-
     @classmethod
     def from_conditions_list(cls, conditions):
         conditions_dict = cls(set)
@@ -50,7 +49,6 @@ class ConditionsDict(defaultdict):
 
 
 class Switch(object):
-
     """
     A switch encapsulates the concept of an item that is either 'on' or 'off'
     depending on the input.  The switch determines this by checking each of its
@@ -258,7 +256,6 @@ class Switch(object):
 
 
 class Condition(object):
-
     """
     A Condition is the configuration of an argument, its attribute and an
     operator. It tells you if it itself is true or false given an input.
@@ -368,7 +365,6 @@ class Condition(object):
 
 
 class Manager(threading.local):
-
     """
     The Manager holds all state for Gutter.  It knows what Switches have been
     registered, and also what Input objects are currently being applied.  It
@@ -507,9 +503,11 @@ class Manager(threading.local):
         # ``register`` is not used here since we do not need/want to sync
         # parental relationships.
         for child in getattr(switch, 'children', []):
-            child = self.storage[self.__namespaced(child)]
-            child.parent = switch.name
-            self.__persist(child)
+            child = self.storage.get(self.__namespaced(child))
+            if child:
+                child.parent = switch.name
+                self.__persist(child)
+
 
     def namespaced(self, namespace):
         new_namespace = []

--- a/gutter/client/models.py
+++ b/gutter/client/models.py
@@ -6,8 +6,8 @@ gutter.models
 :license: Apache License 2.0, see LICENSE for more details.
 """
 
-from gutter.client import signals
 from functools import partial
+from gutter.client import signals
 import threading
 
 
@@ -123,7 +123,12 @@ class Switch(object):
         elif self.state is self.states.DISABLED:
             return signal_decorated(False)
 
-        result = self.__enabled_func(cond.call(inpt) for cond in self.conditions)
+        result = self.__enabled_func(
+            cond.call(inpt)
+            for cond
+            in self.conditions
+            if cond.argument(inpt).applies
+        )
         return signal_decorated(result)
 
     def save(self):
@@ -430,7 +435,7 @@ class Manager(threading.local):
         if switch.concent and switch.get_parent() and not self.active(switch.parent, *inputs, **kwargs):
             return False
 
-        return any(map(switch.enabled_for, inputs))
+        return any(switch.enabled_for(inpt) for inpt in inputs)
 
     def update(self, switch):
 

--- a/gutter/client/settings.py
+++ b/gutter/client/settings.py
@@ -1,8 +1,9 @@
 from durabledict import MemoryDict
+from gutter.client.encoding import JsonPickleEncoding
 
 
 class manager(object):
-    storage_engine = MemoryDict()
+    storage_engine = MemoryDict(encoding=JsonPickleEncoding)
     autocreate = False
     inputs = []
     default = None

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ import sys
 import os
 from setuptools import find_packages
 
+
 try:
     from notsetuptools import setup
 except ImportError:
     from setuptools import setup
-
 
 tests_require = [
     'nose', 'exam', 'mock', 'nose-performance', 'django', 'redis', 'unittest2'
@@ -22,11 +22,9 @@ if 'nosetests' in sys.argv[1:]:
     INSTALLED_APPS = ('gutter.client',)
     SECRET_KEY = 'secret!'
 
-
 if 'flake8' in sys.argv[1:]:
     setup_requires.append('flake8')
     setup_requires.append('dont-fudge-up')
-
 
 setup(
     name='gutter',
@@ -37,7 +35,11 @@ setup(
     description='Client to gutter feature switches backend',
     packages=find_packages(exclude=["tests"]),
     zip_safe=False,
-    install_requires=['durabledict>=0.8.0', 'werkzeug'],
+    install_requires=[
+        'durabledict>=0.9.0',
+        'jsonpickle',
+        'werkzeug',
+    ],
     setup_requires=setup_requires,
     namespace_packages=['gutter'],
     license='Apache License 2.0',

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -22,7 +22,7 @@ class TestBase(unittest2.TestCase):
     subclass_str_arg = fixture(MyArguments, Mock(prop=45))
 
     def test_applies_is_false_if_compatible_type_is_none(self):
-        eq_(self.container.COMPATIBLE_TYPE, None)
+        eq_(self.container.COMPATIBLE_TYPE, type(None))
         eq_(self.container.applies, False)
 
     def applies_is_true_if_input_type_is_compatible_type(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,7 +18,6 @@ from exam.cases import Exam
 
 
 class deterministicstring(str):
-
     """
     Since the percentage-based conditions rely on the hash value from their
     arguments, we use this special deterministicstring class to return
@@ -30,7 +29,6 @@ class deterministicstring(str):
 
 
 class User(object):
-
     def __repr__(self):
         return u'<User "%s" is %d years old>' % (self.name, self.age)
 
@@ -42,7 +40,6 @@ class User(object):
 
 
 class UserArguments(arguments.Container):
-
     COMPATIBLE_TYPE = User
 
     name = arguments.String(lambda self: self.input.name)
@@ -64,7 +61,6 @@ class FloatArguments(arguments.Container):
 
 
 class TestIntegration(Exam, unittest2.TestCase):
-
     class Callback(object):
 
         def __init__(self):
@@ -427,7 +423,6 @@ class TestIntegration(Exam, unittest2.TestCase):
 
 
 class TestIntegrationWithRedis(TestIntegration):
-
     @fixture
     def redis(self):
         return Redis(db=15)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ import zlib
 
 from redis import Redis
 from durabledict.redis import RedisDict
+from gutter.client.encoding import JsonPickleEncoding
 
 from gutter.client.operators.comparable import *
 from gutter.client.operators.identity import *
@@ -286,14 +287,12 @@ class TestIntegration(Exam, unittest2.TestCase):
 
     def test_changing_parent_is_reflected_in_child_switch(self):
         with self.inputs(self.manager, self.jeff) as context:
-            assert self.manager['can drink'].children
             ok_(context.active('can drink:wine') is True)
 
             parent = self.manager['can drink']
             parent.state = Switch.states.DISABLED
             parent.save()
 
-            assert self.manager['can drink'].children
             ok_(context.active('can drink:wine') is False)
 
     def test_switches_can_be_deregistered_and_then_autocreated(self):
@@ -433,7 +432,7 @@ class TestIntegrationWithRedis(TestIntegration):
 
     @fixture
     def manager(self):
-        storage = RedisDict(keyspace='gutter-tests', connection=self.redis)
+        storage = RedisDict(keyspace='gutter-tests', connection=self.redis, encoding=JsonPickleEncoding)
         return Manager(storage=storage)
 
     def test_parent_switch_pickle_input(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
-import unittest2
-import threading
 import itertools
+import threading
+import unittest2
 
 from nose.tools import *
 from gutter.client.arguments import Container as BaseArgument
@@ -9,8 +9,9 @@ from gutter.client.models import Switch, Manager, Condition
 from durabledict import MemoryDict
 from durabledict.base import DurableDict
 from gutter.client import signals
+from gutter.client.operators import comparable
+from gutter.client.arguments import variables
 import mock
-
 from exam.decorators import fixture, before
 from exam.cases import Exam
 
@@ -784,3 +785,57 @@ class NamespacedManagerWithInputTest(ManagerWithInputTest):
     @fixture
     def manager(self):
         return Manager(storage=MemoryDict(), namespace=['a', 'b'])
+
+
+class TestArgumentTyping(Exam, unittest2.TestCase):
+
+    class Foo(BaseArgument):
+        COMPATIBLE_TYPE = int
+        value = arguments.Float(lambda self: self.input)
+
+    class Bar(BaseArgument):
+        COMPATIBLE_TYPE = str
+        value = arguments.String(lambda self: self.input)
+
+    @fixture
+    def switch(self):
+        return Switch(
+            'hi',
+            state=Switch.states.SELECTIVE,
+        )
+
+    @fixture
+    def condition_float(self):
+        return Condition(
+            self.Foo,
+            'value',
+            comparable.Equals(value=1)
+        )
+
+    @fixture
+    def condition_str(self):
+        return Condition(
+            self.Bar,
+            'value',
+            comparable.Equals(value='hi')
+        )
+
+    def test_applies(self):
+        eq_(self.condition_float.argument('hi').applies, False)
+        eq_(self.condition_float.argument(1).applies, True)
+
+    def test_enabled_for(self):
+        self.switch.conditions.append(self.condition_float)
+        eq_(self.switch.enabled_for('hi'), False)
+        eq_(self.switch.enabled_for(1), True)
+
+    def test_enabled_for_when_multiple_COMPATIBLE_TYPEs_exist(self):
+        """
+        if two conditions exist that are of different types then 1 != 'hi'
+        should not make the switch fail as they have different COMPATIBLE_TYPEs
+        """
+
+        self.switch.conditions.append(self.condition_str)
+        self.switch.compounded = True
+        eq_(self.switch.enabled_for('hi'), True)
+        eq_(self.switch.enabled_for(1), True)


### PR DESCRIPTION
There were several bugs involved in maintaining a bidirectional tree of nodes. This diff simplifies the tree by having switches calculate their parent based on their name. A manager can also calculate the children for a switch based on its name.