### PR TITLE
Remove 'Templates' from README.rst ToC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,6 @@ Table of Contents
 * `Checking Switches as Active`_
 * Signals_
 * Namespaces_
-* Templates_
 * Decorators_
 * `Testing Utilities`_
 


### PR DESCRIPTION
There is no 'Templates' section in this document